### PR TITLE
Feat:  issue 18 client device needs canvas UI

### DIFF
--- a/Assets/Runtime/Materials/UiCapturePreviewMaterial.mat
+++ b/Assets/Runtime/Materials/UiCapturePreviewMaterial.mat
@@ -7,8 +7,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: XRVideoMaterial
-  m_Shader: {fileID: 4800000, guid: 75aa85e90979a45d1b3c195ac056bb66, type: 3}
+  m_Name: UiCapturePreviewMaterial
+  m_Shader: {fileID: 10750, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -40,7 +40,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 8400000, guid: dceaada6319e81649a2eadb1afc53f6d, type: 2}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Runtime/Materials/UiCapturePreviewMaterial.mat.meta
+++ b/Assets/Runtime/Materials/UiCapturePreviewMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 339dac43495bce24eae90c3298ada403
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Resources/UiCaptureRenderTexture.renderTexture
+++ b/Assets/Runtime/Resources/UiCaptureRenderTexture.renderTexture
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UiCaptureRenderTexture
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 3
+  m_Width: 540
+  m_Height: 960
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthFormat: 0
+  m_ColorFormat: 8
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 0
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1

--- a/Assets/Runtime/Resources/UiCaptureRenderTexture.renderTexture.meta
+++ b/Assets/Runtime/Resources/UiCaptureRenderTexture.renderTexture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dceaada6319e81649a2eadb1afc53f6d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Scripts/Client.cs
+++ b/Assets/Runtime/Scripts/Client.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -240,18 +241,23 @@ namespace XRRemote
 
         public bool Send(byte[] data) 
         {
-            if (connectionState == ConnectionState.DISCONNECTED) return false;
-            //if (log) Debug.Log(FormatConnectionMessage($"send event from {(tcpClient.Client.LocalEndPoint as IPEndPoint)?.Address} on channel {(tcpClient.Client.RemoteEndPoint as IPEndPoint)?.Address}"));
-            try {
+            try
+            {
+                if (connectionState == ConnectionState.DISCONNECTED) return false;
+
                 NetworkStream stream = tcpClient.GetStream();
                 if (stream.CanWrite) {
-                    stream.Write(data, 0, data.Length);
+                    byte[] dataWithHeader = BitConverter.GetBytes(data.Length).Concat(data).ToArray();
+                    stream.Write(dataWithHeader, 0, dataWithHeader.Length);
+
+                    return true;
                 }
             }
-            catch (Exception e) {
-                Debug.LogException(e);
+            catch (Exception e)
+            {
+                Debug.LogError($"EXCEPTION reason: {e.Message}");
             }
-            return true;
+            return false;
         }
 
         public void ToggleLogLevel(LogLevel logLevel)

--- a/Assets/Runtime/Scripts/DebugFlags.cs
+++ b/Assets/Runtime/Scripts/DebugFlags.cs
@@ -38,6 +38,7 @@ namespace XRRemote
         public static readonly bool displayXRRemotePacketStats = globalDisplay;
         public static readonly bool displayXRRemoteConnectionStats = globalDisplay;
         public static readonly bool displayXRExtractTextureStats = globalDisplay;
+        public static readonly bool displayXRFragmentSender = globalDisplay;
 
     }
 }

--- a/Assets/Runtime/Scripts/FragmentReceiver.cs
+++ b/Assets/Runtime/Scripts/FragmentReceiver.cs
@@ -15,6 +15,7 @@ namespace XRRemote
         private int currentTransmissionId;
         private int currentDataIndex = 0;
         private byte[] dataReceived;
+        private byte[] data;
 
         private int currentPacketCount = 0;
 
@@ -53,10 +54,13 @@ namespace XRRemote
                 return;
             }
 
+            //Decompress data
+            data = CompressionHelper.ByteArrayDecompress(dataReceived);
+
             //Entire data has been sent
             OnDataCompletelyReceived?.Invoke(this, 
                 new OnDataCompletelyReceivedEventArgs {
-                    data = dataReceived
+                    data = this.data
                 }
             );
         }

--- a/Assets/Runtime/Scripts/FragmentReceiver.cs
+++ b/Assets/Runtime/Scripts/FragmentReceiver.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace XRRemote
+{
+    public class OnDataCompletelyReceivedEventArgs : EventArgs
+    {
+        public byte[] data;
+    }
+
+    public class FragmentReceiver : MonoBehaviour
+    {
+        private int currentTransmissionId;
+        private int currentDataIndex = 0;
+        private byte[] dataReceived;
+
+        private int currentPacketCount = 0;
+
+        public event EventHandler OnDataFragmentReceived;
+        public event EventHandler OnDataCompletelyReceived;
+
+        public void PrepareToReceiveBytes(int transmissionId, int expectedSize)
+        {
+            //Prepare data array which will be filled chunk by chunk by the received data
+            currentTransmissionId = transmissionId;
+            dataReceived = new byte[expectedSize];
+            currentDataIndex = 0;
+            currentPacketCount = 0;
+        }
+
+        public void ReceiveBytes(int transmissionId, byte[] recBuffer)
+        {
+            //Make sure receiving data from current transmittion
+            if (transmissionId != currentTransmissionId) {
+                if (DebugFlags.displayXRFragmentSender) {
+                    Debug.LogErrorFormat("FragmentReciever: recieved data for id:{0} but expecting data for id:{1}", transmissionId, currentTransmissionId);
+                }
+                return;
+            }
+
+            //copy received data into prepared array and remember current dataposition
+            System.Array.Copy(recBuffer, 0, dataReceived, currentDataIndex, recBuffer.Length);
+            currentDataIndex += recBuffer.Length;
+
+            currentPacketCount++;
+            OnDataFragmentReceived?.Invoke(this, EventArgs.Empty);
+
+            //Check if completely received data
+            if (currentDataIndex < dataReceived.Length - 1) {
+                return;
+            }
+
+            OnDataCompletelyReceived?.Invoke(this, 
+                new OnDataCompletelyReceivedEventArgs {
+                    data = dataReceived
+                }
+            );
+        }
+        
+    }
+}

--- a/Assets/Runtime/Scripts/FragmentReceiver.cs
+++ b/Assets/Runtime/Scripts/FragmentReceiver.cs
@@ -44,6 +44,7 @@ namespace XRRemote
             System.Array.Copy(recBuffer, 0, dataReceived, currentDataIndex, recBuffer.Length);
             currentDataIndex += recBuffer.Length;
 
+            //Received chunk
             currentPacketCount++;
             OnDataFragmentReceived?.Invoke(this, EventArgs.Empty);
 
@@ -52,6 +53,7 @@ namespace XRRemote
                 return;
             }
 
+            //Entire data has been sent
             OnDataCompletelyReceived?.Invoke(this, 
                 new OnDataCompletelyReceivedEventArgs {
                     data = dataReceived

--- a/Assets/Runtime/Scripts/FragmentReceiver.cs.meta
+++ b/Assets/Runtime/Scripts/FragmentReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dff2ef4e335ecdb4ea7550cfd91d584e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Scripts/FragmentSender.cs
+++ b/Assets/Runtime/Scripts/FragmentSender.cs
@@ -6,39 +6,14 @@ using UnityEngine;
 namespace XRRemote
 {
     [Serializable]
-    public abstract class BaseFragmentPacket 
-    {
-        public int transmissionId;
-    }
-
-    [Serializable]
-    public class StartFragmentPacket : BaseFragmentPacket
-    {
-        public int expectedLength;
-    }
-
-    [Serializable]
-    public class DataFragmentPacket : BaseFragmentPacket
-    {
-        public int index;
-        public byte[] data;
-    }
-
-    [Serializable]
-    public class TestFragmentPacket
-    {
-        public int id;
-    }
-
-    [Serializable]
-    public class TestStartFragmentPacket
+    public class StartFragmentPacket
     {
         public int id;
         public int expectedLength;
     }
 
     [Serializable]
-    public class TestDataFragmentPacket
+    public class DataFragmentPacket
     {
         public int id;
         public int index;
@@ -83,15 +58,8 @@ namespace XRRemote
             isSending = true;
 
             //Tell client that it is going to receive some data and tell it how much it will be.
-            // XREditorClient.Instance.Send(
-            //     new StartFragmentPacket {
-            //         transmissionId = transmissionId,
-            //         expectedLength = data.Length
-            //     }
-            // );
-            Debug.Log($"SendBytesToClientsRoutine: Start message: id = {newId}, dataLength = {data.Length}");
-             //XREditorClient.Instance.Send(new TestFragmentPacket {id = 1}); 
-             XREditorClient.Instance.Send(new TestStartFragmentPacket {id = newId, expectedLength = data.Length}); 
+            //Debug.Log($"SendBytesToClientsRoutine: Start message: id = {newId}, dataLength = {data.Length}");
+            XREditorClient.Instance.Send(new StartFragmentPacket {id = newId, expectedLength = data.Length}); 
             yield return new WaitForSeconds(timeBetweenSendingFragment);
 
             //Transmit data in chunks of bufferSize
@@ -108,16 +76,8 @@ namespace XRRemote
                 System.Array.Copy(data, currentIndex, buffer, 0, bufferSize);
 
                 //Send the chunk
-                // XREditorClient.Instance.Send(
-                //     new DataFragmentPacket {
-                //         transmissionId = transmissionId,
-                //         index = currentIndex,
-                //         data = buffer
-                //     }
-                // );
-                Debug.Log($"SendBytesToClientsRoutine: Send message: id = {currentIndex}");
-                //XREditorClient.Instance.Send(new TestFragmentPacket {id = currentIndex});
-                XREditorClient.Instance.Send(new TestDataFragmentPacket {id = newId, index = currentIndex, data = buffer});
+                //Debug.Log($"SendBytesToClientsRoutine: Send message: id = {currentIndex}");
+                XREditorClient.Instance.Send(new DataFragmentPacket {id = newId, index = currentIndex, data = buffer});
                 currentIndex += bufferSize;
 
                 

--- a/Assets/Runtime/Scripts/FragmentSender.cs
+++ b/Assets/Runtime/Scripts/FragmentSender.cs
@@ -53,7 +53,7 @@ namespace XRRemote
         {
             //Start sending
             transmissionId = newId;
-            data = dataToSend;
+            data = CompressionHelper.ByteArrayCompress(dataToSend);
             currentIndex = 0;
             isSending = true;
 

--- a/Assets/Runtime/Scripts/FragmentSender.cs
+++ b/Assets/Runtime/Scripts/FragmentSender.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace XRRemote
+{
+    [Serializable]
+    public abstract class BaseFragmentPacket 
+    {
+        public int transmissionId;
+    }
+
+    [Serializable]
+    public class StartFragmentPacket : BaseFragmentPacket
+    {
+        public int expectedLength;
+    }
+
+    [Serializable]
+    public class DataFragmentPacket : BaseFragmentPacket
+    {
+        public int index;
+        public byte[] data;
+    }
+
+    [Serializable]
+    public class TestFragmentPacket
+    {
+        public int id;
+    }
+
+    [Serializable]
+    public class TestStartFragmentPacket
+    {
+        public int id;
+        public int expectedLength;
+    }
+
+    [Serializable]
+    public class TestDataFragmentPacket
+    {
+        public int id;
+        public int index;
+        public byte[] data = null;
+    }
+
+#if UNITY_EDITOR
+    public class FragmentSender : MonoBehaviour
+    {
+        private static int defaultBufferSize = 512;
+        private static float timeBetweenSendingFragment = 0.2f;
+
+        private int transmissionId;
+        private byte[] data;
+        private int currentIndex;
+        private bool isSending;
+
+        public event EventHandler OnDataFragmentSent;
+        public event EventHandler OnDataComepletelySent;
+
+
+        public void SendBytesToClient(int transmissionId, byte[] data)
+        {
+            //Check if already currently sending data
+            if (isSending) {
+                if (DebugFlags.displayXRFragmentSender) {
+                    Debug.LogErrorFormat("FragmentSender: Already sending data");
+                }
+                return;
+            }
+
+            //Start sending data
+            StartCoroutine(SendBytesToClientsRoutine(transmissionId, data));
+        }
+
+        private IEnumerator SendBytesToClientsRoutine(int newId, byte[] dataToSend)
+        {
+            //Start sending
+            transmissionId = newId;
+            data = dataToSend;
+            currentIndex = 0;
+            isSending = true;
+
+            //Tell client that it is going to receive some data and tell it how much it will be.
+            // XREditorClient.Instance.Send(
+            //     new StartFragmentPacket {
+            //         transmissionId = transmissionId,
+            //         expectedLength = data.Length
+            //     }
+            // );
+            Debug.Log($"SendBytesToClientsRoutine: Start message: id = {newId}, dataLength = {data.Length}");
+             //XREditorClient.Instance.Send(new TestFragmentPacket {id = 1}); 
+             XREditorClient.Instance.Send(new TestStartFragmentPacket {id = newId, expectedLength = data.Length}); 
+            yield return new WaitForSeconds(timeBetweenSendingFragment);
+
+            //Transmit data in chunks of bufferSize
+            int bufferSize = defaultBufferSize;
+            while(currentIndex < data.Length - 1) {
+                //Determine the remaining amount of bytes, still need to be sent.
+                int remaining = data.Length - currentIndex;
+                if (remaining < bufferSize) {
+                    bufferSize = remaining;
+                }
+
+                //Prepare the chunk of data which will be sent in this iteration
+                byte[] buffer = new byte[bufferSize];
+                System.Array.Copy(data, currentIndex, buffer, 0, bufferSize);
+
+                //Send the chunk
+                // XREditorClient.Instance.Send(
+                //     new DataFragmentPacket {
+                //         transmissionId = transmissionId,
+                //         index = currentIndex,
+                //         data = buffer
+                //     }
+                // );
+                Debug.Log($"SendBytesToClientsRoutine: Send message: id = {currentIndex}");
+                //XREditorClient.Instance.Send(new TestFragmentPacket {id = currentIndex});
+                XREditorClient.Instance.Send(new TestDataFragmentPacket {id = newId, index = currentIndex, data = buffer});
+                currentIndex += bufferSize;
+
+                
+                yield return new WaitForSeconds(timeBetweenSendingFragment);
+
+                //Fragment sent
+                OnDataFragmentSent?.Invoke(this, EventArgs.Empty);
+            }
+
+            //Complete send
+            transmissionId = -1;
+            Array.Clear(data, 0, data.Length);
+            isSending = false;
+
+            //Transmission complete
+            OnDataComepletelySent?.Invoke(this, EventArgs.Empty);
+        }
+    }
+#endif
+}

--- a/Assets/Runtime/Scripts/FragmentSender.cs
+++ b/Assets/Runtime/Scripts/FragmentSender.cs
@@ -23,8 +23,8 @@ namespace XRRemote
 #if UNITY_EDITOR
     public class FragmentSender : MonoBehaviour
     {
-        private static int defaultBufferSize = 512;
-        private static float timeBetweenSendingFragment = 0.2f;
+        private static int defaultBufferSize = 800;
+        private static float timeBetweenSendingFragment = 0.15f;
 
         private int transmissionId;
         private byte[] data;
@@ -58,7 +58,7 @@ namespace XRRemote
             isSending = true;
 
             //Tell client that it is going to receive some data and tell it how much it will be.
-            //Debug.Log($"SendBytesToClientsRoutine: Start message: id = {newId}, dataLength = {data.Length}");
+            Debug.Log($"SendBytesToClientsRoutine: Start message: id = {newId}, dataLength = {data.Length} at {Time.time}");
             XREditorClient.Instance.Send(new StartFragmentPacket {id = newId, expectedLength = data.Length}); 
             yield return new WaitForSeconds(timeBetweenSendingFragment);
 
@@ -88,6 +88,7 @@ namespace XRRemote
             }
 
             //Complete send
+            Debug.Log($"SendBytesToClientsRoutine: Send complete: id = {transmissionId} at {Time.time}");
             transmissionId = -1;
             Array.Clear(data, 0, data.Length);
             isSending = false;

--- a/Assets/Runtime/Scripts/FragmentSender.cs.meta
+++ b/Assets/Runtime/Scripts/FragmentSender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a17c154290aed2c4eb1e9bed76b279e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Scripts/TextureScale.cs
+++ b/Assets/Runtime/Scripts/TextureScale.cs
@@ -1,0 +1,154 @@
+// Only works on ARGB32, RGB24 and Alpha8 textures that are marked readable
+// Author: Eric Haines (Eric5h5)
+// Source: http://wiki.unity3d.com/index.php/TextureScale
+ 
+using System.Threading;
+using UnityEngine;
+ 
+public class TextureScale
+{
+	public class ThreadData
+	{
+	    public int start;
+	    public int end;
+		public ThreadData (int s, int e) {
+			start = s;
+			end = e;
+		}
+	}
+ 
+    private static Color[] texColors;
+    private static Color[] newColors;
+    private static int w;
+    private static float ratioX;
+    private static float ratioY;
+    private static int w2;
+    private static int finishCount;
+    private static Mutex mutex;
+ 
+	public static void Point (Texture2D tex, int newWidth, int newHeight)
+    {
+		ThreadedScale (tex, newWidth, newHeight, false);
+	}
+ 
+	public static void Bilinear (Texture2D tex, int newWidth, int newHeight)
+    {
+		ThreadedScale (tex, newWidth, newHeight, true);
+	}
+ 
+	private static void ThreadedScale (Texture2D tex, int newWidth, int newHeight, bool useBilinear)
+    {
+		texColors = tex.GetPixels();
+		newColors = new Color[newWidth * newHeight];
+		if (useBilinear)
+        {
+			ratioX = 1.0f / ((float)newWidth / (tex.width-1));
+			ratioY = 1.0f / ((float)newHeight / (tex.height-1));
+		}
+		else {
+			ratioX = ((float)tex.width) / newWidth;
+			ratioY = ((float)tex.height) / newHeight;
+		}
+		w = tex.width;
+		w2 = newWidth;
+		var cores = Mathf.Min(SystemInfo.processorCount, newHeight);
+		var slice = newHeight/cores;
+ 
+		finishCount = 0;
+		if (mutex == null) {
+			mutex = new Mutex(false);
+		}
+		if (cores > 1)
+		{
+		    int i = 0;
+		    ThreadData threadData;
+			for (i = 0; i < cores-1; i++) {
+                threadData = new ThreadData(slice * i, slice * (i + 1));
+                ParameterizedThreadStart ts = useBilinear ? new ParameterizedThreadStart(BilinearScale) : new ParameterizedThreadStart(PointScale);
+			    Thread thread = new Thread(ts);
+				thread.Start(threadData);
+			}
+			threadData = new ThreadData(slice*i, newHeight);
+			if (useBilinear)
+            {
+				BilinearScale(threadData);
+			}
+			else
+            {
+				PointScale(threadData);
+			}
+			while (finishCount < cores)
+            {
+                Thread.Sleep(1);
+            }
+		}
+		else
+        {
+			ThreadData threadData = new ThreadData(0, newHeight);
+			if (useBilinear)
+            {
+				BilinearScale(threadData);
+			}
+			else
+            {
+				PointScale(threadData);
+			}
+		}
+ 
+		tex.Resize(newWidth, newHeight);
+		tex.SetPixels(newColors);
+		tex.Apply();
+ 
+		texColors = null;
+		newColors = null;
+	}
+ 
+	public static void BilinearScale (System.Object obj)
+	{
+	    ThreadData threadData = (ThreadData) obj;
+		for (var y = threadData.start; y < threadData.end; y++)
+        {
+			int yFloor = (int)Mathf.Floor(y * ratioY);
+			var y1 = yFloor * w;
+			var y2 = (yFloor+1) * w;
+			var yw = y * w2;
+ 
+			for (var x = 0; x < w2; x++) {
+				int xFloor = (int)Mathf.Floor(x * ratioX);
+				var xLerp = x * ratioX-xFloor;
+				newColors[yw + x] = ColorLerpUnclamped(ColorLerpUnclamped(texColors[y1 + xFloor], texColors[y1 + xFloor+1], xLerp),
+													   ColorLerpUnclamped(texColors[y2 + xFloor], texColors[y2 + xFloor+1], xLerp),
+													   y*ratioY-yFloor);
+			}
+		}
+ 
+		mutex.WaitOne();
+		finishCount++;
+		mutex.ReleaseMutex();
+	}
+ 
+	public static void PointScale (System.Object obj)
+	{
+	    ThreadData threadData = (ThreadData) obj;
+		for (var y = threadData.start; y < threadData.end; y++)
+        {
+			var thisY = (int)(ratioY * y) * w;
+			var yw = y * w2;
+			for (var x = 0; x < w2; x++) {
+				newColors[yw + x] = texColors[(int)(thisY + ratioX*x)];
+			}
+		}
+ 
+		mutex.WaitOne();
+		finishCount++;
+		mutex.ReleaseMutex();
+	}
+ 
+	private static Color ColorLerpUnclamped (Color c1, Color c2, float value)
+    {
+        return new Color (c1.r + (c2.r - c1.r)*value, 
+						  c1.g + (c2.g - c1.g)*value, 
+						  c1.b + (c2.b - c1.b)*value, 
+						  c1.a + (c2.a - c1.a)*value);
+    }
+}

--- a/Assets/Runtime/Scripts/TextureScale.cs.meta
+++ b/Assets/Runtime/Scripts/TextureScale.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5cb842b2cea8bb4c804cfb06f3edec6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Scripts/XREditorClient.cs
+++ b/Assets/Runtime/Scripts/XREditorClient.cs
@@ -408,7 +408,7 @@ namespace XRRemote
         }
 
         /// <summary>
-        /// Create packet and send UI to Player
+        /// Create packet and send compressed UI to Player
         /// </summary>
         public void SendXRUICapturePacketToPlayer(OnUICapturedArgs obj)
         {

--- a/Assets/Runtime/Scripts/XREditorClient.cs
+++ b/Assets/Runtime/Scripts/XREditorClient.cs
@@ -425,6 +425,10 @@ namespace XRRemote
         {
             if (obj is XRRemotePacket) OnXRRemotePacketReceived(obj as XRRemotePacket);
             if (obj is ARSessionHandShakePacket) OnARSessionHandShakeAck(obj as ARSessionHandShakePacket);
+            if (obj is XRRemoteServerOnConnectPacket) {
+                XRRemoteServerOnConnectPacket connectionPacket = obj as XRRemoteServerOnConnectPacket;
+                Debug.LogError($"ConnectionPacket: Canvas Size = {connectionPacket.canvasWidth} x {connectionPacket.canvasHeight}");
+            }
         }
 
         private void remoteUICapture_OnUICaptured(object sender, EventArgs e)

--- a/Assets/Runtime/Scripts/XREditorClient.cs
+++ b/Assets/Runtime/Scripts/XREditorClient.cs
@@ -65,6 +65,12 @@ namespace XRRemote
         /// </summary>
         XRRemoteVideo remoteVideo;
 
+        /// <summary>
+        /// Reference to the remote UI Capture which
+        /// will be send UI texture
+        /// </summary>
+        XRRemoteUICapture remoteUICapture;
+
         /////////////////////////////////////////////////////////////////////////
 
         // CONNECTIONS
@@ -174,6 +180,8 @@ namespace XRRemote
             // initialize the plane delivery system from
             // the player. 
             TrySetUpXRRemotePlaneManager();
+
+            TrySetupRemoteUICapture();
         }
 
         void OnGUI()
@@ -212,6 +220,10 @@ namespace XRRemote
         public new void OnDisable()
         {
             base.OnDisable();
+
+            if (remoteUICapture != null) {
+                remoteUICapture.OnUICaptured -= remoteUICapture_OnUICaptured;
+            }
         }
         
         private void InitializeXRPlayer()
@@ -353,7 +365,26 @@ namespace XRRemote
                 }
             }
         }
-    #endregion
+
+        private void TrySetupRemoteUICapture()
+        {
+            if (remoteUICapture != null) return;
+
+            remoteUICapture = FindObjectOfType<XRRemoteUICapture>();
+            if (remoteUICapture == null)
+            {
+                if (DebugFlags.displayXRRemoteConnectionStats)
+                {
+                    Debug.LogErrorFormat(
+                        XRRemoteConnectionMessage(
+                            string.Format("TrySetupRemoteUICapture Event: null XRRemoteUICapture")));
+                    return;
+                }
+            }
+
+            remoteUICapture.OnUICaptured += remoteUICapture_OnUICaptured;
+        }
+        #endregion
 
         /// <summary>
         /// When the client responds that the session has been properly initialized. 
@@ -376,10 +407,26 @@ namespace XRRemote
             base.Send(serializableObject);
         }
 
+        /// <summary>
+        /// Create packet and send UI to Player
+        /// </summary>
+        public void SendXRUICapturePacketToPlayer(OnUICapturedArgs obj)
+        {
+            Send(new XRUICapturePacket {
+                frameCount = obj.frameCount,
+                textureData = obj.data,
+            });
+        }
+
         public override void MessageReceived(object obj)
         {
             if (obj is XRRemotePacket) OnXRRemotePacketReceived(obj as XRRemotePacket);
             if (obj is ARSessionHandShakePacket) OnARSessionHandShakeAck(obj as ARSessionHandShakePacket);
+        }
+
+        private void remoteUICapture_OnUICaptured(object sender, EventArgs e)
+        {
+            SendXRUICapturePacketToPlayer(e as OnUICapturedArgs);
         }
     }
 #endif

--- a/Assets/Runtime/Scripts/XREditorClient.cs
+++ b/Assets/Runtime/Scripts/XREditorClient.cs
@@ -181,6 +181,9 @@ namespace XRRemote
             // the player. 
             TrySetUpXRRemotePlaneManager();
 
+            //
+            // initialize the UI component and texture
+            // needed to send canvas to device
             TrySetupRemoteUICapture();
         }
 

--- a/Assets/Runtime/Scripts/XREditorClient.cs
+++ b/Assets/Runtime/Scripts/XREditorClient.cs
@@ -417,6 +417,7 @@ namespace XRRemote
         {
             Send(new XRUICapturePacket {
                 frameCount = obj.frameCount,
+                timeStamp = obj.timeStamp,
                 textureData = obj.data,
             });
         }
@@ -427,7 +428,7 @@ namespace XRRemote
             if (obj is ARSessionHandShakePacket) OnARSessionHandShakeAck(obj as ARSessionHandShakePacket);
             if (obj is XRRemoteServerOnConnectPacket) {
                 XRRemoteServerOnConnectPacket connectionPacket = obj as XRRemoteServerOnConnectPacket;
-                Debug.LogError($"ConnectionPacket: Canvas Size = {connectionPacket.canvasWidth} x {connectionPacket.canvasHeight}");
+                Debug.Log($"ConnectionPacket: Canvas Size = {connectionPacket.canvasWidth} x {connectionPacket.canvasHeight}");
             }
         }
 

--- a/Assets/Runtime/Scripts/XRRemoteInputSystem.cs
+++ b/Assets/Runtime/Scripts/XRRemoteInputSystem.cs
@@ -47,8 +47,8 @@ namespace XRRemote
                 canvasSize.x = Screen.currentResolution.height;//canvas.GetComponent<RectTransform>().rect.height;
                 canvasSize.y = Screen.currentResolution.width;//canvas.GetComponent<RectTransform>().rect.width;
 
-                Debug.Log($"Screen size: {Screen.currentResolution.width} x {Screen.currentResolution.height}");
-                Debug.Log($"Canvas size: {canvas.GetComponent<RectTransform>().rect.height} x {canvas.GetComponent<RectTransform>().rect.width}");
+                // Debug.Log($"Screen size: {Screen.currentResolution.width} x {Screen.currentResolution.height}");
+                // Debug.Log($"Canvas size: {canvas.GetComponent<RectTransform>().rect.height} x {canvas.GetComponent<RectTransform>().rect.width}");
             }
 
             if (canvas == null) {
@@ -77,6 +77,7 @@ namespace XRRemote
 
         private void OnDisable()
         {
+            if (XREditorClient.Instance == null) return;
             XREditorClient.Instance.OnInputDataReceived -= XREditorClient_OnInputDataReceived;
         }
 

--- a/Assets/Runtime/Scripts/XRRemoteInputSystem.cs
+++ b/Assets/Runtime/Scripts/XRRemoteInputSystem.cs
@@ -44,8 +44,11 @@ namespace XRRemote
             Canvas canvas = FindObjectOfType<Canvas>();
 
             if (canvas != null) {
-                canvasSize.x = canvas.GetComponent<RectTransform>().rect.height;
-                canvasSize.y = canvas.GetComponent<RectTransform>().rect.width;
+                canvasSize.x = Screen.currentResolution.height;//canvas.GetComponent<RectTransform>().rect.height;
+                canvasSize.y = Screen.currentResolution.width;//canvas.GetComponent<RectTransform>().rect.width;
+
+                Debug.Log($"Screen size: {Screen.currentResolution.width} x {Screen.currentResolution.height}");
+                Debug.Log($"Canvas size: {canvas.GetComponent<RectTransform>().rect.height} x {canvas.GetComponent<RectTransform>().rect.width}");
             }
 
             if (canvas == null) {
@@ -85,8 +88,8 @@ namespace XRRemote
 
             //Update touch position
             touchPosition = new Vector2(
-                XREditorClient.Instance.touchPositionNormalized.x * canvasSize.x,
-                XREditorClient.Instance.touchPositionNormalized.y * canvasSize.y
+                XREditorClient.Instance.touchPositionNormalized.x * canvasSize.x * 2,
+                XREditorClient.Instance.touchPositionNormalized.y * canvasSize.y / 2
             );
 
             //Create an input event on the new Input System

--- a/Assets/Runtime/Scripts/XRRemotePacket.cs
+++ b/Assets/Runtime/Scripts/XRRemotePacket.cs
@@ -42,6 +42,7 @@ namespace XRRemote
     [Serializable]
     public class XRUICapturePacket {
         public int frameCount;
+        public long timeStamp;
         public byte[] textureData = null;
     }
     

--- a/Assets/Runtime/Scripts/XRRemotePacket.cs
+++ b/Assets/Runtime/Scripts/XRRemotePacket.cs
@@ -38,6 +38,12 @@ namespace XRRemote
     public class ARSessionHandShakePacket {
         public bool value;
     }
+
+    [Serializable]
+    public class XRUICapturePacket {
+        public int frameCount;
+        public byte[] textureData;
+    }
     
     [Serializable]
     public class EditorARKitSessionInitialized {

--- a/Assets/Runtime/Scripts/XRRemotePacket.cs
+++ b/Assets/Runtime/Scripts/XRRemotePacket.cs
@@ -238,4 +238,10 @@ namespace XRRemote
         }
     }
 
+    [Serializable]
+    public class XRRemoteServerOnConnectPacket
+    {
+        public float canvasWidth;
+        public float canvasHeight;
+    }
 }

--- a/Assets/Runtime/Scripts/XRRemotePacket.cs
+++ b/Assets/Runtime/Scripts/XRRemotePacket.cs
@@ -42,7 +42,7 @@ namespace XRRemote
     [Serializable]
     public class XRUICapturePacket {
         public int frameCount;
-        public byte[] textureData;
+        public byte[] textureData = null;
     }
     
     [Serializable]

--- a/Assets/Runtime/Scripts/XRRemotePlaneManager.cs
+++ b/Assets/Runtime/Scripts/XRRemotePlaneManager.cs
@@ -23,6 +23,8 @@ namespace XRRemote
 
         private void OnDisable()
         {
+            if (XREditorClient.Instance == null) return;
+            
             XREditorClient.Instance.OnPlanesInfoReceived -= XREditorClient_OnPlanesInfoReceived;
         }
 

--- a/Assets/Runtime/Scripts/XRRemoteServer.cs
+++ b/Assets/Runtime/Scripts/XRRemoteServer.cs
@@ -250,6 +250,12 @@ namespace XRRemote
             if (!SetUpInputSystem(this.inputReader)) return;
             if (!SetupRemoteCanvas()) return;
             if (!SetupUIReceiver()) return;
+
+            if (!SendOnConnectPacket()) {
+                if (log) {
+                    Debug.LogErrorFormat("XRRemoteServer: Unable to send connection packet!");
+                }
+            }
 #if UNITY_ANDROID
             //
             // make sure we have a way to get access to the
@@ -455,6 +461,24 @@ namespace XRRemote
             }
 
             return true; 
+        }
+
+        private bool SendOnConnectPacket()
+        {
+            XRRemoteServerOnConnectPacket connectionPacket = new XRRemoteServerOnConnectPacket();
+
+            Canvas canvas = FindObjectOfType<Canvas>();
+
+            if (canvas == null) return false;
+
+            if (canvas.TryGetComponent<RectTransform>(out RectTransform canvaasRectTransform)) {
+                connectionPacket.canvasWidth = canvaasRectTransform.rect.width;
+                connectionPacket.canvasHeight = canvaasRectTransform.rect.height;
+            } else {
+                return false;
+            }
+
+            return Send(connectionPacket);
         }
         #endregion
 

--- a/Assets/Runtime/Scripts/XRRemoteServer.cs
+++ b/Assets/Runtime/Scripts/XRRemoteServer.cs
@@ -583,6 +583,9 @@ namespace XRRemote
             readyForFrame = packet.value;
         }
 
+        /// <summary>
+        /// Display compressed UI canvas preview
+        /// </summary>
         private void OnUICaptureRecieved(XRUICapturePacket xrUiCapturePacket)
         {
             if (remoteCanvas == null) return;
@@ -599,21 +602,20 @@ namespace XRRemote
             remoteCanvas.enabled = true;
         }
 
-        private void OnUIFragmentRecieved(BaseFragmentPacket fragmentPacket)
-        {
-            if (uiReceiver == null) return;
-
-            uiReceiver.ReceiveFragmentPacket(fragmentPacket);
-        }
-
-        private void OnUIStartFragmentRecieved(TestStartFragmentPacket startfragmentPacket)
+        /// <summary>
+        /// Start receiving UI canvas data
+        /// </summary>
+        private void OnUIStartFragmentRecieved(StartFragmentPacket startfragmentPacket)
         {
             if (uiReceiver == null) return;
 
             uiReceiver.ReceiveStartFragmentPacket(startfragmentPacket);
         }
 
-        private void OnUIDataFragmentRecieved(TestDataFragmentPacket datafragmentPacket)
+        /// <summary>
+        /// Receive UI canvas data fragments
+        /// </summary>
+        private void OnUIDataFragmentRecieved(DataFragmentPacket datafragmentPacket)
         {
             if (uiReceiver == null) return;
 
@@ -661,21 +663,8 @@ namespace XRRemote
             if (obj is XRFrameReadyPacket) OnReadyForFrameEvent(obj as XRFrameReadyPacket);
             if (obj is EditorARKitSessionInitialized) OnARKitSessionInitializationMessage(obj as EditorARKitSessionInitialized);
             if (obj is XRUICapturePacket) OnUICaptureRecieved(obj as XRUICapturePacket);
-            if (obj is BaseFragmentPacket) OnUIFragmentRecieved(obj as BaseFragmentPacket);
-            if (obj is TestFragmentPacket) {
-                TestFragmentPacket packet = obj as TestFragmentPacket;
-                Debug.LogError($"MessageReceived: id = {packet.id}");
-            }
-            if (obj is TestStartFragmentPacket) {
-                TestStartFragmentPacket packet = obj as TestStartFragmentPacket;
-                //Debug.LogError($"MessageReceived: id = {packet.id}, expectedLength = {packet.expectedLength}");
-                OnUIStartFragmentRecieved(packet);
-            }
-            if (obj is TestDataFragmentPacket) {
-                TestDataFragmentPacket packet = obj as TestDataFragmentPacket;
-                //Debug.LogError($"MessageReceived: id = {packet.id}, index = {packet.index}, buffer_size = {packet.data.Length}");
-                OnUIDataFragmentRecieved(packet);
-            }
+            if (obj is StartFragmentPacket) OnUIStartFragmentRecieved(obj as StartFragmentPacket);
+            if (obj is DataFragmentPacket) OnUIDataFragmentRecieved(obj as DataFragmentPacket);
         }
     }
 }

--- a/Assets/Runtime/Scripts/XRRemoteServer.cs
+++ b/Assets/Runtime/Scripts/XRRemoteServer.cs
@@ -621,8 +621,10 @@ namespace XRRemote
             System.DateTime captureTime = System.DateTime.FromBinary(xrUiCapturePacket.timeStamp);
             Debug.LogError($"Capture took {currentTime.Subtract(captureTime).ToString()}");
 
-            //Read data as Texture2d
-            remoteCanvasTexture.LoadImage(xrUiCapturePacket.textureData);
+            //Decompress and read data as Texture2d
+            //Decompress data
+            byte[] dataReceived = CompressionHelper.ByteArrayDecompress(xrUiCapturePacket.textureData);
+            remoteCanvasTexture.LoadImage(dataReceived);
             remoteCanvasTexture.Apply();
 
             //Show remote canvas

--- a/Assets/Runtime/Scripts/XRRemoteServer.cs
+++ b/Assets/Runtime/Scripts/XRRemoteServer.cs
@@ -617,6 +617,10 @@ namespace XRRemote
             //Debug.LogError($"OnUICaptureRecieved: id=" + xrUiCapturePacket.frameCount);
             //Debug.Log($"OnUICaptureRecieved: data length=" + xrUiCapturePacket.textureData.Length);
 
+            System.DateTime currentTime = System.DateTime.Now;
+            System.DateTime captureTime = System.DateTime.FromBinary(xrUiCapturePacket.timeStamp);
+            Debug.LogError($"Capture took {currentTime.Subtract(captureTime).ToString()}");
+
             //Read data as Texture2d
             remoteCanvasTexture.LoadImage(xrUiCapturePacket.textureData);
             remoteCanvasTexture.Apply();

--- a/Assets/Runtime/Scripts/XRRemoteTouchVisual.cs
+++ b/Assets/Runtime/Scripts/XRRemoteTouchVisual.cs
@@ -11,7 +11,7 @@ namespace XRRemote
     public class XRRemoteTouchVisual : MonoBehaviour
     {
         private float timeToShowVisual = 0.1f;
-        private float fadeScale = 5f;
+        private float fadeScale = 10f;
         private float timeSinceVisible = float.PositiveInfinity;
 
         [SerializeField] private RectTransform imageRectTransform;

--- a/Assets/Runtime/Scripts/XRRemoteTouchVisual.cs
+++ b/Assets/Runtime/Scripts/XRRemoteTouchVisual.cs
@@ -42,6 +42,8 @@ namespace XRRemote
             imageRectTransform.localScale = Vector3.one * Mathf.Lerp(1f, fadeScale, timeSinceVisible / timeToShowVisual);
 
             timeSinceVisible += Time.deltaTime;
+
+            rectTransform.SetAsLastSibling();
         }
 
         private void XRRemoteInputSystem_OnTouch(object sender, EventArgs e)

--- a/Assets/Runtime/Scripts/XRRemoteUICapture.cs
+++ b/Assets/Runtime/Scripts/XRRemoteUICapture.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class XRRemoteUICapture : MonoBehaviour
+{
+    [SerializeField] private Canvas uiCanvas;
+    [SerializeField] private Camera uiCamera;
+    [SerializeField] private RenderTexture targetTexture;
+
+    private void Awake()
+    {
+        //Initialize targetTexture
+        if (targetTexture == null) {
+            //Default texture size
+            int width = 1080 / 2;
+            int height = 1920 / 2;
+            int colorDepth = 8;
+
+            //If canvas is found, use its dimensions instead
+            if (uiCanvas != null) {
+                RectTransform uiCanvasRectTransform = GetComponent<RectTransform>();
+                width = Mathf.RoundToInt(uiCanvasRectTransform.rect.width);
+                height = Mathf.RoundToInt(uiCanvasRectTransform.rect.height);
+            }
+
+            //Create a new RenderTexture
+            targetTexture = new RenderTexture(
+                width,
+                height,
+                colorDepth
+            );
+        }
+    }
+
+    public void CaptureUiToRenderTexture()
+    {
+        //Save canvas's previous state
+        Camera prevCam = uiCanvas.worldCamera;
+        RenderMode prevRenderMode = uiCanvas.renderMode;
+
+        //Enable UI Camera and ready canvas for capture
+        uiCamera.gameObject.SetActive(true);
+        uiCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+        uiCanvas.worldCamera = uiCamera;
+        uiCamera.targetTexture = targetTexture;
+
+        //Capture the UI layer
+        uiCamera.Render();
+
+        //Restore canvas's previous state and disable UI Camera
+        uiCamera.targetTexture = null;
+        uiCanvas.worldCamera = prevCam;
+        uiCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        uiCamera.gameObject.SetActive(false);
+    }
+}

--- a/Assets/Runtime/Scripts/XRRemoteUICapture.cs
+++ b/Assets/Runtime/Scripts/XRRemoteUICapture.cs
@@ -9,6 +9,7 @@ namespace XRRemote
     public class OnUICapturedArgs : EventArgs
     {
         public int frameCount;
+        public long timeStamp;
         public byte[] data;
     }
 
@@ -59,6 +60,18 @@ namespace XRRemote
                     Debug.LogWarningFormat("XRRemoteUICapture: required FragmentSender component not found.");
                 }
             }
+        }
+
+        private void Start()
+        {
+            StartCoroutine(StreamUiToDevice());
+        }
+
+        private IEnumerator StreamUiToDevice()
+        {
+            float timeBetweenFrames = 0.25f;
+            CaptureUiToRenderTexture();
+            yield return new WaitForSeconds(timeBetweenFrames);
         }
 
         public void CaptureUiToRenderTexture()

--- a/Assets/Runtime/Scripts/XRRemoteUICapture.cs
+++ b/Assets/Runtime/Scripts/XRRemoteUICapture.cs
@@ -4,94 +4,123 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class OnUICapturedArgs : EventArgs
+namespace XRRemote
 {
-    public int frameCount;
-    public byte[] data;
-}
-
-public class XRRemoteUICapture : MonoBehaviour
-{
-    public event EventHandler OnUICaptured;
-
-    [SerializeField] private Canvas uiCanvas;
-    [SerializeField] private Camera uiCamera;
-    [SerializeField] private RenderTexture targetTexture;
-
-    [SerializeField] private RawImage testImage;
-
-    int canvasWidth = 1080;
-    int canvasHeight = 1920;
-    int width = 1080 / 15;
-    int height = 1920 / 15;
-    int depthBuffer = 0;    
-
-    private void Awake()
+    public class OnUICapturedArgs : EventArgs
     {
-        // Initialize targetTexture
-        if (targetTexture == null) {
-            //Create a new RenderTexture
-            targetTexture = new RenderTexture(
-                width,
-                height,
-                depthBuffer,
-                RenderTextureFormat.ARGB32
-            );
-            Debug.Log($"Created new texture");
-        }
-
-        //If canvas is found, use its dimensions instead
-        if (uiCanvas != null) {
-            RectTransform uiCanvasRectTransform = GetComponent<RectTransform>();
-            canvasWidth = Mathf.RoundToInt(uiCanvasRectTransform.rect.width);
-            canvasHeight = Mathf.RoundToInt(uiCanvasRectTransform.rect.height);
-        }
+        public int frameCount;
+        public byte[] data;
     }
 
-    public void CaptureUiToRenderTexture()
+#if UNITY_EDITOR
+    public class XRRemoteUICapture : MonoBehaviour
     {
-        //Save canvas's previous state
-        Camera prevCam = uiCanvas.worldCamera;
-        RenderMode prevRenderMode = uiCanvas.renderMode;
+        public event EventHandler OnUICaptured;
 
-        //Enable UI Camera and ready canvas for capture
-        uiCamera.gameObject.SetActive(true);
-        uiCanvas.renderMode = RenderMode.ScreenSpaceCamera;
-        uiCanvas.worldCamera = uiCamera;
-        uiCamera.targetTexture = targetTexture;
+        [SerializeField] private Canvas uiCanvas;
+        [SerializeField] private Camera uiCamera;
+        [SerializeField] private RenderTexture targetTexture;
 
-        //Capture the UI layer to targetTexture
-        uiCamera.Render();
+        [SerializeField] private RawImage testImage;
 
-        //Restore canvas's previous state and disable UI Camera
-        uiCamera.targetTexture = null;
-        uiCanvas.worldCamera = prevCam;
-        uiCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
-        uiCamera.gameObject.SetActive(false);
+        int canvasWidth = 1080;
+        int canvasHeight = 1920;
+        int width = 1080 / 15;
+        int height = 1920 / 15;
+        int depthBuffer = 0;
 
-        //Save targetTexture as Texture2D
-        Texture2D uiScreenShot = new Texture2D(canvasWidth / 2, canvasHeight / 2, TextureFormat.RGBA32, false);
-        RenderTexture.active = targetTexture;
-        uiScreenShot.ReadPixels(new Rect(0,0, targetTexture.width, targetTexture.height), 0, 0);
-        RenderTexture.active = null;
-        //TextureScale.Point(uiScreenShot, width, height);
-        byte[] textureData = uiScreenShot.EncodeToPNG();
-        Debug.Log($"Texture data is {textureData.Length} bytes");
+        [SerializeField] private FragmentSender fragmentSender;
 
-        //test
-        if (testImage != null) {
-            Texture2D remoteCanvasTexture = new Texture2D(canvasWidth, canvasHeight, TextureFormat.RGBA32, false);
-            remoteCanvasTexture.LoadImage(textureData);
-            remoteCanvasTexture.Apply();
+        private void Awake()
+        {
+            // Initialize targetTexture
+            if (targetTexture == null) {
+                //Create a new RenderTexture
+                targetTexture = new RenderTexture(
+                    width,
+                    height,
+                    depthBuffer,
+                    RenderTextureFormat.ARGB32
+                );
+            }
 
-            Debug.Log($"OnUICaptureRecieved: {remoteCanvasTexture.width} x {remoteCanvasTexture.height}");
-            testImage.texture = remoteCanvasTexture;
+            //If canvas is found, use its dimensions instead
+            // if (uiCanvas != null) {
+            //     RectTransform uiCanvasRectTransform = uiCanvas.GetComponent<RectTransform>();
+            //     canvasWidth = Mathf.RoundToInt(uiCanvasRectTransform.rect.width);
+            //     canvasHeight = Mathf.RoundToInt(uiCanvasRectTransform.rect.height);
+            // }
+
+            fragmentSender = GetComponent<FragmentSender>();
         }
 
-        //Broadcast event
-        OnUICaptured?.Invoke(this, new OnUICapturedArgs {
-            frameCount = Time.frameCount,
-            data = textureData,
-        });
+        private void OnEnable()
+        {
+            fragmentSender.OnDataFragmentSent += FragmentSender_OnDataFragmentSent;
+            fragmentSender.OnDataComepletelySent += FragmentSender_OnDataComepletelySent;
+        }
+
+        public void CaptureUiToRenderTexture()
+        {
+            //Save canvas's previous state
+            Camera prevCam = uiCanvas.worldCamera;
+            RenderMode prevRenderMode = uiCanvas.renderMode;
+
+            //Enable UI Camera and ready canvas for capture
+            uiCamera.gameObject.SetActive(true);
+            uiCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+            uiCanvas.worldCamera = uiCamera;
+            uiCamera.targetTexture = targetTexture;
+
+            //Capture the UI layer to targetTexture
+            uiCamera.Render();
+
+            //Restore canvas's previous state and disable UI Camera
+            uiCamera.targetTexture = null;
+            uiCanvas.worldCamera = prevCam;
+            uiCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            uiCamera.gameObject.SetActive(false);
+
+            //Save targetTexture as Texture2D
+            Texture2D uiScreenShot = new Texture2D(canvasWidth / 2, canvasHeight / 2, TextureFormat.RGBA32, false);
+            RenderTexture.active = targetTexture;
+            uiScreenShot.ReadPixels(new Rect(0,0, targetTexture.width, targetTexture.height), 0, 0);
+            RenderTexture.active = null;
+
+            byte[] textureData = uiScreenShot.EncodeToPNG();
+            Debug.Log($"Texture UNcompressed data is {textureData.Length} bytes");
+            fragmentSender.SendBytesToClient(Time.frameCount, textureData);
+            
+            TextureScale.Point(uiScreenShot, width, height);
+            textureData = uiScreenShot.EncodeToPNG();
+            Debug.Log($"Texture compressed data is {textureData.Length} bytes");
+
+            //test: Show preview on Client
+            if (testImage != null) {
+                Texture2D remoteCanvasTexture = new Texture2D(canvasWidth, canvasHeight, TextureFormat.RGBA32, false);
+                remoteCanvasTexture.LoadImage(textureData);
+                remoteCanvasTexture.Apply();
+
+                Debug.Log($"OnUICaptureRecieved: {remoteCanvasTexture.width} x {remoteCanvasTexture.height}");
+                testImage.texture = remoteCanvasTexture;
+            }
+
+            //Broadcast event
+            OnUICaptured?.Invoke(this, new OnUICapturedArgs {
+                frameCount = Time.frameCount,
+                data = textureData,
+            });
+        }
+
+        private void FragmentSender_OnDataComepletelySent(object sender, EventArgs e)
+        {
+            Debug.Log($"Data completely sent!");
+        }
+
+        private void FragmentSender_OnDataFragmentSent(object sender, EventArgs e)
+        {
+            //Debug.Log($"Fragment sent!");
+        }
     }
+#endif
 }

--- a/Assets/Runtime/Scripts/XRRemoteUICapture.cs
+++ b/Assets/Runtime/Scripts/XRRemoteUICapture.cs
@@ -20,6 +20,7 @@ namespace XRRemote
         [SerializeField] private Canvas uiCanvas;
         [SerializeField] private Camera uiCamera;
         [SerializeField] private RenderTexture targetTexture;
+        [SerializeField] LayerMask layerToCapture;
 
         [SerializeField] private RawImage testImage;
 
@@ -29,7 +30,7 @@ namespace XRRemote
         int height = 1920 / 15;
         int depthBuffer = 0;
 
-        [SerializeField] private FragmentSender fragmentSender;
+        private FragmentSender fragmentSender;
 
         private void Awake()
         {
@@ -71,6 +72,7 @@ namespace XRRemote
             uiCanvas.renderMode = RenderMode.ScreenSpaceCamera;
             uiCanvas.worldCamera = uiCamera;
             uiCamera.targetTexture = targetTexture;
+            uiCamera.cullingMask = layerToCapture;
 
             //Capture the UI layer to targetTexture
             uiCamera.Render();

--- a/Assets/Runtime/Scripts/XRRemoteUICapture.cs.meta
+++ b/Assets/Runtime/Scripts/XRRemoteUICapture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cb9c8829487b8e4ab48466075f30a4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Scripts/XRRemoteUIReceiver.cs
+++ b/Assets/Runtime/Scripts/XRRemoteUIReceiver.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace XRRemote
+{
+    public class XRRemoteUIReceiver : MonoBehaviour
+    {
+        private FragmentReceiver fragmentReceiver;
+
+        private void Awake()
+        {
+            fragmentReceiver = GetComponent<FragmentReceiver>();
+        }
+
+        private void OnEnable()
+        {
+            fragmentReceiver.OnDataCompletelyReceived += FragmentReceiver_OnDataCompletelyReceived;
+        }
+
+        private void OnDisable()
+        {
+            fragmentReceiver.OnDataCompletelyReceived -= FragmentReceiver_OnDataCompletelyReceived;
+        }
+
+        public void ReceiveStartFragmentPacket(TestStartFragmentPacket startFragmentPacket)
+        {
+            Debug.LogError($"XRRemoteUIReceiver: received START fragment. id = {startFragmentPacket.id}, expectedLength = {startFragmentPacket.expectedLength}");
+            fragmentReceiver.PrepareToReceiveBytes(startFragmentPacket.id, startFragmentPacket.expectedLength);
+        }
+
+        public void ReceiveDataFragmentPacket(TestDataFragmentPacket dataFragmentPacket)
+        {
+            Debug.LogError($"XRRemoteUIReceiver: received DATA fragment. id = {dataFragmentPacket.id}, dataLength = {dataFragmentPacket.data.Length}");
+            fragmentReceiver.ReceiveBytes(dataFragmentPacket.id, dataFragmentPacket.data);
+        }
+
+        public void ReceiveFragmentPacket(BaseFragmentPacket fragmentPacket)
+        {
+            switch (fragmentPacket)
+            {
+                case StartFragmentPacket startFragmentPacket:
+                    Debug.LogError($"XRRemoteUIReceiver: received START fragment");
+                    fragmentReceiver.PrepareToReceiveBytes(startFragmentPacket.transmissionId, startFragmentPacket.expectedLength);
+                    break;
+
+                case DataFragmentPacket dataFragmentPacket:
+                    Debug.LogError($"XRRemoteUIReceiver: completely DATA fragment");
+                    fragmentReceiver.ReceiveBytes(dataFragmentPacket.transmissionId, dataFragmentPacket.data);
+                    break;
+
+                default:
+                    Debug.LogError($"XRRemoteUIReceiver: unknown fragment type");
+                    break;
+            }
+        }
+
+        private void FragmentReceiver_OnDataCompletelyReceived(object sender, EventArgs e)
+        {
+            OnDataCompletelyReceivedEventArgs args = e as OnDataCompletelyReceivedEventArgs;
+
+            Debug.LogError($"XRRemoteUIReceiver: completely received data {args.data.ToString()}");
+
+            //Read data as Texture2d
+            Texture2D remoteCanvasTexture = new Texture2D(100, 100, TextureFormat.RGBA32, false);
+            remoteCanvasTexture.LoadImage(args.data);
+            remoteCanvasTexture.Apply();
+
+            //Show remote canvas
+            XRRemoteServer.Instance.remoteCanvas.texture = remoteCanvasTexture;
+            XRRemoteServer.Instance.remoteCanvas.enabled = true;
+        }
+    }
+}

--- a/Assets/Runtime/Scripts/XRRemoteUIReceiver.cs.meta
+++ b/Assets/Runtime/Scripts/XRRemoteUIReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5c55b0eecc09324884a2d6f623577ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -288,7 +288,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -75}
-  m_SizeDelta: {x: 200, y: 50}
+  m_SizeDelta: {x: 400, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &231695044
 MonoBehaviour:
@@ -1380,7 +1380,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 2
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1080, y: 1920}
@@ -1519,8 +1519,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 48
+  m_fontSizeBase: 48
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 0

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -214,6 +214,43 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &229863120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 229863121}
+  m_Layer: 5
+  m_Name: UICapturePreview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &229863121
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229863120}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 473463988}
+  - {fileID: 941740734}
+  m_Father: {fileID: 685474686}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 10, y: 10}
+  m_SizeDelta: {x: 54, y: 96}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &231695042
 GameObject:
   m_ObjectHideFlags: 0
@@ -246,7 +283,7 @@ RectTransform:
   m_Children:
   - {fileID: 689647930}
   m_Father: {fileID: 685474686}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -346,6 +383,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 231695042}
+  m_CullTransparentMesh: 1
+--- !u!1 &233924878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 233924879}
+  - component: {fileID: 233924881}
+  - component: {fileID: 233924880}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &233924879
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233924878}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &233924880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233924878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: New Text
+--- !u!222 &233924881
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233924878}
   m_CullTransparentMesh: 1
 --- !u!1 &283682590
 GameObject:
@@ -556,7 +672,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &453675960
 RectTransform:
   m_ObjectHideFlags: 0
@@ -564,12 +680,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 453675959}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 685474686}
-  m_RootOrder: 3
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -613,6 +729,172 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 453675959}
+  m_CullTransparentMesh: 1
+--- !u!1 &473463987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 473463988}
+  - component: {fileID: 473463991}
+  - component: {fileID: 473463990}
+  - component: {fileID: 473463989}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &473463988
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 473463987}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 229863121}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &473463989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 473463987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: -3}
+  m_UseGraphicAlpha: 1
+--- !u!114 &473463990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 473463987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.05882353}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &473463991
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 473463987}
+  m_CullTransparentMesh: 1
+--- !u!1 &482196331
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 482196332}
+  - component: {fileID: 482196334}
+  - component: {fileID: 482196333}
+  m_Layer: 5
+  m_Name: Image (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &482196332
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 482196331}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &482196333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 482196331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.9374714, a: 0.38431373}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &482196334
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 482196331}
   m_CullTransparentMesh: 1
 --- !u!1 &506440168
 GameObject:
@@ -682,7 +964,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 506440168}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!4 &506440171
 Transform:
   m_ObjectHideFlags: 0
@@ -697,6 +979,81 @@ Transform:
   m_Father: {fileID: 605699978}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &510694160
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 510694161}
+  - component: {fileID: 510694163}
+  - component: {fileID: 510694162}
+  m_Layer: 5
+  m_Name: Image (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &510694161
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 510694160}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 1, y: 0}
+--- !u!114 &510694162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 510694160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.9374714, a: 0.38431373}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &510694163
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 510694160}
+  m_CullTransparentMesh: 1
 --- !u!1 &583297793
 GameObject:
   m_ObjectHideFlags: 0
@@ -708,6 +1065,7 @@ GameObject:
   - component: {fileID: 583297794}
   - component: {fileID: 583297797}
   - component: {fileID: 583297795}
+  - component: {fileID: 583297796}
   m_Layer: 5
   m_Name: XRRemoteTouchVisual
   m_TagString: Untagged
@@ -728,7 +1086,7 @@ RectTransform:
   m_Children:
   - {fileID: 2109227031}
   m_Father: {fileID: 685474686}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -748,6 +1106,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   imageRectTransform: {fileID: 2109227031}
+--- !u!114 &583297796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 583297793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 99
 --- !u!222 &583297797
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -788,6 +1166,7 @@ MonoBehaviour:
   uiCanvas: {fileID: 685474685}
   uiCamera: {fileID: 506440169}
   targetTexture: {fileID: 8400000, guid: dceaada6319e81649a2eadb1afc53f6d, type: 2}
+  testImage: {fileID: 941740735}
 --- !u!4 &605699978
 Transform:
   m_ObjectHideFlags: 0
@@ -972,6 +1351,7 @@ GameObject:
   - component: {fileID: 685474685}
   - component: {fileID: 685474684}
   - component: {fileID: 685474683}
+  - component: {fileID: 685474687}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1051,10 +1431,10 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 583297794}
   - {fileID: 231695043}
-  - {fileID: 1997221568}
-  - {fileID: 453675960}
+  - {fileID: 583297794}
+  - {fileID: 768861946}
+  - {fileID: 229863121}
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1063,6 +1443,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &685474687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 685474682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e74ab7d411268e48bd37afd0ba2d5be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &689647929
 GameObject:
   m_ObjectHideFlags: 0
@@ -1197,6 +1589,122 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 689647929}
   m_CullTransparentMesh: 1
+--- !u!1 &768861945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 768861946}
+  m_Layer: 5
+  m_Name: TestUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &768861946
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 768861945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 233924879}
+  - {fileID: 453675960}
+  - {fileID: 1997221568}
+  - {fileID: 1073546162}
+  - {fileID: 1726017816}
+  - {fileID: 2128545872}
+  - {fileID: 510694161}
+  - {fileID: 482196332}
+  - {fileID: 1240474870}
+  m_Father: {fileID: 685474686}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &941740733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 941740734}
+  - component: {fileID: 941740736}
+  - component: {fileID: 941740735}
+  m_Layer: 5
+  m_Name: RawImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &941740734
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 941740733}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 229863121}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &941740735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 941740733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &941740736
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 941740733}
+  m_CullTransparentMesh: 1
 --- !u!1 &1056015953
 GameObject:
   m_ObjectHideFlags: 0
@@ -1255,8 +1763,158 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1760703bbd54c04488a8d10600262ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_PlanePrefab: {fileID: 8752457894863012287, guid: d3f86bdc1ce21304c83d9e3efe17f566, type: 3}
+  m_PlanePrefab: {fileID: 0}
   m_DetectionMode: -1
+--- !u!1 &1073546161
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1073546162}
+  - component: {fileID: 1073546164}
+  - component: {fileID: 1073546163}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1073546162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073546161}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1073546163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073546161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.9374714, a: 0.38431373}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1073546164
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073546161}
+  m_CullTransparentMesh: 1
+--- !u!1 &1240474869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1240474870}
+  - component: {fileID: 1240474872}
+  - component: {fileID: 1240474871}
+  m_Layer: 5
+  m_Name: Image (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1240474870
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240474869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1240474871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240474869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.9374714, a: 0.38431373}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1240474872
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240474869}
+  m_CullTransparentMesh: 1
 --- !u!1 &1272421868
 GameObject:
   m_ObjectHideFlags: 0
@@ -1349,6 +2007,81 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1726017815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1726017816}
+  - component: {fileID: 1726017818}
+  - component: {fileID: 1726017817}
+  m_Layer: 5
+  m_Name: Image (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1726017816
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726017815}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &1726017817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726017815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.9374714, a: 0.38431373}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1726017818
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726017815}
+  m_CullTransparentMesh: 1
 --- !u!1 &1879742329
 GameObject:
   m_ObjectHideFlags: 0
@@ -1425,7 +2158,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1997221568
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1433,11 +2166,11 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1997221567}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 685474686}
+  m_Father: {fileID: 768861946}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -1616,4 +2349,79 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2109227030}
+  m_CullTransparentMesh: 1
+--- !u!1 &2128545871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2128545872}
+  - component: {fileID: 2128545874}
+  - component: {fileID: 2128545873}
+  m_Layer: 5
+  m_Name: Image (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2128545872
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128545871}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 768861946}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &2128545873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128545871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.9374714, a: 0.38431373}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2128545874
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128545871}
   m_CullTransparentMesh: 1

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -1380,10 +1380,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 2
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1080, y: 1920}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -1148,7 +1148,7 @@ MonoBehaviour:
   targetTexture: {fileID: 8400000, guid: dceaada6319e81649a2eadb1afc53f6d, type: 2}
   layerToCapture:
     serializedVersion: 2
-    m_Bits: 32
+    m_Bits: 33
   testImage: {fileID: 941740735}
 --- !u!4 &605699978
 Transform:
@@ -1615,6 +1615,101 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &932121578
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 932121582}
+  - component: {fileID: 932121581}
+  - component: {fileID: 932121580}
+  - component: {fileID: 932121579}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &932121579
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932121578}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &932121580
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932121578}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &932121581
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932121578}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &932121582
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932121578}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &941740733
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -167,6 +167,101 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &181725818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 181725822}
+  - component: {fileID: 181725821}
+  - component: {fileID: 181725820}
+  - component: {fileID: 181725819}
+  m_Layer: 0
+  m_Name: Sphere (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &181725819
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 181725818}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &181725820
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 181725818}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &181725821
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 181725818}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &181725822
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 181725818}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &205345044
 GameObject:
   m_ObjectHideFlags: 0
@@ -1149,6 +1244,7 @@ MonoBehaviour:
   layerToCapture:
     serializedVersion: 2
     m_Bits: 33
+  textureScaleFactor: 1
   testImage: {fileID: 941740735}
 --- !u!4 &605699978
 Transform:
@@ -1917,6 +2013,101 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1073546161}
   m_CullTransparentMesh: 1
+--- !u!1 &1083880526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1083880530}
+  - component: {fileID: 1083880529}
+  - component: {fileID: 1083880528}
+  - component: {fileID: 1083880527}
+  m_Layer: 0
+  m_Name: Sphere (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1083880527
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083880526}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1083880528
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083880526}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1083880529
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083880526}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1083880530
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083880526}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1240474869
 GameObject:
   m_ObjectHideFlags: 0
@@ -2502,3 +2693,98 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2128545871}
   m_CullTransparentMesh: 1
+--- !u!1 &2129531757
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2129531761}
+  - component: {fileID: 2129531760}
+  - component: {fileID: 2129531759}
+  - component: {fileID: 2129531758}
+  m_Layer: 0
+  m_Name: Sphere (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &2129531758
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2129531757}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2129531759
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2129531757}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2129531760
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2129531757}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2129531761
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2129531757}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -287,7 +287,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -100}
+  m_AnchoredPosition: {x: 0, y: -75}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &231695044
@@ -1065,7 +1065,6 @@ GameObject:
   - component: {fileID: 583297794}
   - component: {fileID: 583297797}
   - component: {fileID: 583297795}
-  - component: {fileID: 583297796}
   m_Layer: 5
   m_Name: XRRemoteTouchVisual
   m_TagString: Untagged
@@ -1106,26 +1105,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   imageRectTransform: {fileID: 2109227031}
---- !u!114 &583297796
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 583297793}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreLayout: 0
-  m_MinWidth: -1
-  m_MinHeight: -1
-  m_PreferredWidth: -1
-  m_PreferredHeight: -1
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 99
 --- !u!222 &583297797
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1144,6 +1123,7 @@ GameObject:
   m_Component:
   - component: {fileID: 605699978}
   - component: {fileID: 605699977}
+  - component: {fileID: 605699979}
   m_Layer: 0
   m_Name: XRRemoteUICapture
   m_TagString: Untagged
@@ -1167,6 +1147,7 @@ MonoBehaviour:
   uiCamera: {fileID: 506440169}
   targetTexture: {fileID: 8400000, guid: dceaada6319e81649a2eadb1afc53f6d, type: 2}
   testImage: {fileID: 941740735}
+  fragmentSender: {fileID: 605699979}
 --- !u!4 &605699978
 Transform:
   m_ObjectHideFlags: 0
@@ -1182,6 +1163,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &605699979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 605699976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a17c154290aed2c4eb1e9bed76b279e0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &625929126
 GameObject:
   m_ObjectHideFlags: 0
@@ -1351,7 +1344,6 @@ GameObject:
   - component: {fileID: 685474685}
   - component: {fileID: 685474684}
   - component: {fileID: 685474683}
-  - component: {fileID: 685474687}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1443,18 +1435,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &685474687
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 685474682}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7e74ab7d411268e48bd37afd0ba2d5be, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &689647929
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -249,7 +249,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 10, y: 10}
-  m_SizeDelta: {x: 54, y: 96}
+  m_SizeDelta: {x: 281.6591, y: 500.7273}
   m_Pivot: {x: 0, y: 0}
 --- !u!1 &231695042
 GameObject:
@@ -1146,8 +1146,10 @@ MonoBehaviour:
   uiCanvas: {fileID: 685474685}
   uiCamera: {fileID: 506440169}
   targetTexture: {fileID: 8400000, guid: dceaada6319e81649a2eadb1afc53f6d, type: 2}
+  layerToCapture:
+    serializedVersion: 2
+    m_Bits: 32
   testImage: {fileID: 941740735}
-  fragmentSender: {fileID: 605699979}
 --- !u!4 &605699978
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -212,8 +212,141 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &231695042
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 231695043}
+  - component: {fileID: 231695046}
+  - component: {fileID: 231695045}
+  - component: {fileID: 231695044}
+  m_Layer: 5
+  m_Name: CaptureUIButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &231695043
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 231695042}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 689647930}
+  m_Father: {fileID: 685474686}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -100}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &231695044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 231695042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 231695045}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 605699977}
+        m_TargetAssemblyTypeName: XRRemoteUICapture, upm-xrremote
+        m_MethodName: CaptureUiToRenderTexture
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &231695045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 231695042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &231695046
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 231695042}
+  m_CullTransparentMesh: 1
 --- !u!1 &283682590
 GameObject:
   m_ObjectHideFlags: 0
@@ -404,7 +537,165 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &453675959
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 453675960}
+  - component: {fileID: 453675962}
+  - component: {fileID: 453675961}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &453675960
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453675959}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 685474686}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -163.2}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &453675961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453675959}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 13e7e6fe43a8aa049bcd610bbc1f5ff8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &453675962
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453675959}
+  m_CullTransparentMesh: 1
+--- !u!1 &506440168
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 506440171}
+  - component: {fileID: 506440169}
+  - component: {fileID: 506440170}
+  m_Layer: 0
+  m_Name: UICamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!20 &506440169
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506440168}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 32
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &506440170
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506440168}
+  m_Enabled: 1
+--- !u!4 &506440171
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506440168}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 605699978}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &583297793
 GameObject:
@@ -465,6 +756,149 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 583297793}
   m_CullTransparentMesh: 1
+--- !u!1 &605699976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 605699978}
+  - component: {fileID: 605699977}
+  m_Layer: 0
+  m_Name: XRRemoteUICapture
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &605699977
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 605699976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cb9c8829487b8e4ab48466075f30a4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uiCanvas: {fileID: 685474685}
+  uiCamera: {fileID: 506440169}
+  targetTexture: {fileID: 8400000, guid: dceaada6319e81649a2eadb1afc53f6d, type: 2}
+--- !u!4 &605699978
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 605699976}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 506440171}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &625929126
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625929130}
+  - component: {fileID: 625929129}
+  - component: {fileID: 625929128}
+  - component: {fileID: 625929127}
+  m_Layer: 0
+  m_Name: UiCapturePreview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &625929127
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625929126}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &625929128
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625929126}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 339dac43495bce24eae90c3298ada403, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &625929129
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625929126}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &625929130
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625929126}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: -0.7071068, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 1, z: 1.6}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 90, y: 180, z: 0}
 --- !u!850595691 &637971101
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -602,7 +1036,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -618,14 +1052,151 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 583297794}
+  - {fileID: 231695043}
+  - {fileID: 1997221568}
+  - {fileID: 453675960}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &689647929
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 689647930}
+  - component: {fileID: 689647932}
+  - component: {fileID: 689647931}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &689647930
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689647929}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 231695043}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &689647931
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689647929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Capture UI
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 0
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &689647932
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689647929}
+  m_CullTransparentMesh: 1
 --- !u!1 &1056015953
 GameObject:
   m_ObjectHideFlags: 0
@@ -716,6 +1287,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   XRRemotePlaneVisualPrefab: {fileID: 1107657557705778436, guid: e139c43fa38022641801498dd04b6e2b, type: 3}
+  xrPlaneVisualList: []
 --- !u!4 &1272421870
 Transform:
   m_ObjectHideFlags: 0
@@ -836,6 +1408,140 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1997221567
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1997221568}
+  - component: {fileID: 1997221570}
+  - component: {fileID: 1997221569}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1997221568
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997221567}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 685474686}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 135.13}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1997221569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997221567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Test UI Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1997221570
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997221567}
+  m_CullTransparentMesh: 1
 --- !u!1 &2109227030
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/Scenes/AR Remote Server.unity
+++ b/Assets/Samples/Scenes/AR Remote Server.unity
@@ -123,6 +123,62 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &277970145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 277970148}
+  - component: {fileID: 277970147}
+  - component: {fileID: 277970146}
+  m_Layer: 0
+  m_Name: XR Remote UIReceiver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &277970146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277970145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5c55b0eecc09324884a2d6f623577ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &277970147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277970145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dff2ef4e335ecdb4ea7550cfd91d584e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &277970148
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277970145}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &326968388
 GameObject:
   m_ObjectHideFlags: 0
@@ -366,6 +422,7 @@ MonoBehaviour:
   textureExtractor: {fileID: 0}
   inputReader: {fileID: 0}
   remoteCanvas: {fileID: 0}
+  uiReceiver: {fileID: 0}
 --- !u!4 &524972719
 Transform:
   m_ObjectHideFlags: 0
@@ -416,7 +473,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 400, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &872633145
@@ -752,7 +809,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1273626150
 GameObject:
@@ -1486,7 +1543,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2120512255
 MonoBehaviour:
@@ -1652,7 +1709,7 @@ RectTransform:
   - {fileID: 1529808755}
   - {fileID: 421758503}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/Assets/Samples/Scenes/AR Remote Server.unity
+++ b/Assets/Samples/Scenes/AR Remote Server.unity
@@ -166,6 +166,42 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &421758502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 421758503}
+  m_Layer: 5
+  m_Name: RemoteCanvasContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &421758503
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421758502}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1987511055}
+  m_Father: {fileID: 2124080295}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &465525293
 GameObject:
   m_ObjectHideFlags: 0
@@ -329,6 +365,7 @@ MonoBehaviour:
   renderTextureHeight: 311
   textureExtractor: {fileID: 0}
   inputReader: {fileID: 0}
+  remoteCanvas: {fileID: 0}
 --- !u!4 &524972719
 Transform:
   m_ObjectHideFlags: 0
@@ -1193,6 +1230,78 @@ Transform:
   m_Father: {fileID: 1577406471}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1987511054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1987511055}
+  - component: {fileID: 1987511057}
+  - component: {fileID: 1987511056}
+  m_Layer: 5
+  m_Name: XRRemoteUICanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1987511055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987511054}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 421758503}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1987511056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987511054}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1987511057
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987511054}
+  m_CullTransparentMesh: 1
 --- !u!1 &2060402739
 GameObject:
   m_ObjectHideFlags: 0
@@ -1541,6 +1650,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1529808755}
+  - {fileID: 421758503}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
# PR Summary 

This PR closes github issue #18 .  UI from the Unity editor is captured and sent to client device.  A low-resolution placeholder is sent while a FragmentSender sends a full version of the canvas. XRRemoteUICapture can be configured to sent only the UI or with the Default LayerMask to send gameObject to the device.

## IDE Improvements 

Found issues
IssueGroupingObjectModel(groupName=Severity, text=WARNING, icon=ImageSourceIconModel (iconPackStringId = "SolutionAnalysis"iconNameStringId = "SolutionAnalysisWarning"))
IssueGroupingObjectModel(groupName=Severity, text=ERROR, icon=ImageSourceIconModel (iconPackStringId = "SolutionAnalysis"iconNameStringId = "SolutionAnalysisError"))
IssueGroupingObjectModel(groupName=Severity, text=SUGGESTION, icon=ImageSourceIconModel (iconPackStringId = "SolutionAnalysis"iconNameStringId = "SolutionAnalysisSuggestion"))
IssueGroupingObjectModel(groupName=Severity, text=HINT, icon=ImageSourceIconModel (iconPackStringId = "SolutionAnalysis"iconNameStringId = "SolutionAnalysisHint"))

## QA Summary 

## :ledger: Notes

No additional notes were given.

## :chart_with_downwards_trend: Logs

No (crash) logs were given. 

#### Build Status

- [x] Build Passes ✅ 
- [x] Build Fails :x: 
---> 
![Screenshot: Unity Editor](https://user-images.githubusercontent.com/67300046/231976134-74b74bec-d23b-4832-aa62-9e8960b6d2e3.jpg)
![Screenshot: Client device with UI Capture sent](https://user-images.githubusercontent.com/67300046/231976146-1b44ba8e-dad4-4c20-b1c0-5061a8cfc473.png)
