### PR TITLE
Issue 40 plane tag and debug tags are annoying to setup

### DIFF
--- a/Assets/Editor/SetupTools.cs
+++ b/Assets/Editor/SetupTools.cs
@@ -1,0 +1,81 @@
+using UnityEditor;
+using UnityEngine;
+ 
+public static class SetupTools
+{
+    [MenuItem("Tools/Setup Layers")]
+    [InitializeOnLoadMethod]
+    public static void SetupLayers()
+    {
+        Debug.Log("Adding Layers.");
+ 
+        Object[] asset = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset");
+ 
+        if (asset != null && asset.Length > 0)
+        {
+            SerializedObject serializedObject = new SerializedObject(asset[0]);
+            SerializedProperty layers = serializedObject.FindProperty("layers");
+         
+           // Add your layers here, these are just examples. Keep in mind: indices below 6 are the built in layers.
+            AddLayerAt(layers,  6, "Planes");
+            AddLayerAt(layers,  7, "XRRemote-Debug");
+ 
+            serializedObject.ApplyModifiedProperties();
+            serializedObject.Update();
+        }
+    }
+ 
+    static void AddLayerAt(SerializedProperty layers, int index, string layerName, bool tryOtherIndex = true)
+   {
+       // Skip if a layer with the name already exists.
+       for (int i = 0; i < layers.arraySize; ++i)
+       {
+           if (layers.GetArrayElementAtIndex(i).stringValue == layerName)
+           {
+               Debug.Log("Skipping layer '" + layerName + "' because it already exists.");
+               return;
+           }
+       }
+ 
+       // Extend layers if necessary
+       if (index >= layers.arraySize)
+           layers.arraySize = index + 1;
+ 
+       // set layer name at index
+       var element = layers.GetArrayElementAtIndex(index);
+       if (string.IsNullOrEmpty(element.stringValue))
+       {
+           element.stringValue = layerName;
+           Debug.Log("Added layer '" + layerName + "' at index " + index + ".");
+       }
+       else
+       {
+           Debug.LogWarning("Could not add layer at index " + index + " because there already is another layer '" + element.stringValue + "'." );
+ 
+           if (tryOtherIndex)
+           {
+               // Go up in layer indices and try to find an empty spot.
+               for (int i = index + 1; i < 32; ++i)
+               {
+                   // Extend layers if necessary
+                   if (i >= layers.arraySize)
+                       layers.arraySize = i + 1;
+ 
+                   element = layers.GetArrayElementAtIndex(i);
+                   if (string.IsNullOrEmpty(element.stringValue))
+                   {
+                       element.stringValue = layerName;
+                       Debug.Log("Added layer '" + layerName + "' at index " + i + " instead of " + index + ".");
+                       return;
+                   }
+               }
+ 
+               Debug.LogError("Could not add layer " + layerName + " because there is no space left in the layers array.");
+           }
+       }
+   }
+ 
+}
+ 
+
+

--- a/Assets/Editor/SetupTools.cs.meta
+++ b/Assets/Editor/SetupTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 928dad67e4299e6468742354cd30b8d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Prefabs/XR Remote Connection.prefab
+++ b/Assets/Runtime/Prefabs/XR Remote Connection.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 7970182264650845405}
   - component: {fileID: 7970182264650845394}
-  - component: {fileID: 1797568351400850950}
   m_Layer: 0
   m_Name: XR Remote Connection
   m_TagString: Untagged
@@ -48,15 +47,3 @@ MonoBehaviour:
   IP: 192.168.0.
   _connectionState: 0
   xrRemoteTrackingState: 0
---- !u!114 &1797568351400850950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7970182264650845395}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acf53a66fa41349088296461e6ce0210, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Runtime/Scripts/XREditorClient.cs
+++ b/Assets/Runtime/Scripts/XREditorClient.cs
@@ -247,6 +247,14 @@ namespace XRRemote
 
         private void TrySetUpXRRemoteVideo()
         {
+            if (Camera.main == null)
+            {
+                Debug.LogErrorFormat(
+                    XRRemoteConnectionMessage(
+                        "TrySetUpXRRemoteVideo Error: AR Camera not set as MainCamera"));
+                return;
+            }
+            
             remoteVideo = Camera.main.GetComponent<XRRemoteVideo>();
             if (remoteVideo == null)
             {

--- a/Assets/Samples/Scenes/AR Remote Client.unity
+++ b/Assets/Samples/Scenes/AR Remote Client.unity
@@ -135,7 +135,7 @@ GameObject:
   - component: {fileID: 283682591}
   - component: {fileID: 283682593}
   - component: {fileID: 283682592}
-  - component: {fileID: 283682594}
+  - component: {fileID: 283682596}
   m_Layer: 0
   m_Name: AR Camera
   m_TagString: MainCamera
@@ -217,18 +217,6 @@ MonoBehaviour:
   m_AutoFocus: 1
   m_LightEstimation: 0
   m_FacingDirection: 1
---- !u!114 &283682594
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283682590}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6e3c44306fb1e439a9f18b2212b8ab70, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &283682595
 Transform:
   m_ObjectHideFlags: 0
@@ -243,6 +231,24 @@ Transform:
   m_Father: {fileID: 1056015955}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &283682596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 283682590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a2a9c34df4095f47b9ca8f975175f5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Device: 0
+  m_PoseSource: 2
+  m_PoseProviderComponent: {fileID: 0}
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_UseRelativeTransform: 0
 --- !u!850595691 &637971101
 LightingSettings:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/Scenes/AR Remote Server.unity
+++ b/Assets/Samples/Scenes/AR Remote Server.unity
@@ -123,102 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &348896845
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 348896846}
-  - component: {fileID: 348896849}
-  - component: {fileID: 348896848}
-  - component: {fileID: 348896847}
-  m_Layer: 5
-  m_Name: Quad (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &348896846
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348896845}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -224.1, y: -706, z: 0}
-  m_LocalScale: {x: 210.28629, y: 210.28629, z: 210.28629}
-  m_Children: []
-  m_Father: {fileID: 1795854790}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &348896847
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348896845}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &348896848
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348896845}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: dad7100a818384c3ab779ee6cb472697, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &348896849
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348896845}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &465525293
 GameObject:
   m_ObjectHideFlags: 0
@@ -372,7 +276,7 @@ MonoBehaviour:
   logLevel: 1
   _connectionState: 0
   cameraManager: {fileID: 1864567044}
-  arPoseDriver: {fileID: 1864567045}
+  arPoseDriver: {fileID: 0}
   connectionText: {fileID: 1169207675}
   arSystemBarText: {fileID: 998094292}
   testConnectionButton: {fileID: 465525295}
@@ -395,102 +299,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &724643590
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 724643591}
-  - component: {fileID: 724643594}
-  - component: {fileID: 724643593}
-  - component: {fileID: 724643592}
-  m_Layer: 5
-  m_Name: Quad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &724643591
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 724643590}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 25, y: -706, z: 0}
-  m_LocalScale: {x: 210.28629, y: 210.28629, z: 210.28629}
-  m_Children: []
-  m_Father: {fileID: 1795854790}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &724643592
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 724643590}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &724643593
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 724643590}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: dd08d0444df7f45879f408837ab677fb, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &724643594
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 724643590}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &872633143
 GameObject:
   m_ObjectHideFlags: 0
@@ -1192,52 +1000,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1795854789
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1795854790}
-  - component: {fileID: 1795854791}
-  m_Layer: 5
-  m_Name: TestMatMat
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &1795854790
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1795854789}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.057, y: 0.003, z: 0.685}
-  m_LocalScale: {x: 0.0004063419, y: 0.0004063419, z: 0.0004063419}
-  m_Children:
-  - {fileID: 724643591}
-  - {fileID: 1980747893}
-  - {fileID: 348896846}
-  m_Father: {fileID: 1864567046}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1795854791
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1795854789}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 65fdff4e48dcb4662b7580c04ee634e4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1864567041
 GameObject:
   m_ObjectHideFlags: 0
@@ -1341,9 +1103,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 1864567041}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6e3c44306fb1e439a9f18b2212b8ab70, type: 3}
+  m_Script: {fileID: 11500000, guid: 5a2a9c34df4095f47b9ca8f975175f5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Device: 0
+  m_PoseSource: 2
+  m_PoseProviderComponent: {fileID: 0}
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_UseRelativeTransform: 0
 --- !u!4 &1864567046
 Transform:
   m_ObjectHideFlags: 0
@@ -1354,107 +1122,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1795854790}
+  m_Children: []
   m_Father: {fileID: 1577406471}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1980747892
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1980747893}
-  - component: {fileID: 1980747896}
-  - component: {fileID: 1980747895}
-  - component: {fileID: 1980747894}
-  m_Layer: 5
-  m_Name: Quad (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1980747893
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980747892}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 264, y: -706, z: 0}
-  m_LocalScale: {x: 210.28629, y: 210.28629, z: 210.28629}
-  m_Children: []
-  m_Father: {fileID: 1795854790}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1980747894
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980747892}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &1980747895
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980747892}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 64b9cb92d3717436695d70e7a8c70e25, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1980747896
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980747892}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &2060402739
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.youar.upm-xrremote",
     "displayName": "upm-xrremote",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "unity": "2020.3",
     "description": "Allows you to use data from mobile device to help build and test AR applications with Unity.",
     "samples": [


### PR DESCRIPTION
SetupTools.cs runs a script on editor load to add Planes and XRRemote-Debug to the layers list.  Additionally, there is a menu button called 'Tools' with an option to 'Setup Layers' which does the same thing, but you shouldn't have to click it since the method is run on editor startup. We can add additional functionality to this later if we want.

There is some error handling in the creation of the layers to make sure we're not overwriting an already labeled layer (we just target the next unlabeled layer) and an error log if for some reason there are no available layers whatsoever.